### PR TITLE
add a test settings file, to force the tests to x64, so the correct Oracle driver is loaded.

### DIFF
--- a/BVT/Data.BVT/.runsettings
+++ b/BVT/Data.BVT/.runsettings
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- x86 or x64 -->
+    <!-- This is required because the Oracle client library is x64 -->
+    <TargetPlatform>x64</TargetPlatform>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
The Oracle tests throw BadImageException, because they run in 32bit, while the Oracle driver is 64bit. This forces the tests to run in x64, and exposes some real tests failures.