### PR TITLE
Fix issue 23

### DIFF
--- a/source/Src/Data/Oracle/OracleDatabase.cs
+++ b/source/Src/Data/Oracle/OracleDatabase.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
 using Microsoft.Practices.EnterpriseLibrary.Data.Oracle.Configuration;
 using Microsoft.Practices.EnterpriseLibrary.Data.Properties;
+using Oracle.ManagedDataAccess.Types;
 
 namespace Microsoft.Practices.EnterpriseLibrary.Data.Oracle
 {
@@ -354,6 +355,17 @@ namespace Microsoft.Practices.EnterpriseLibrary.Data.Oracle
 
         private static object ConvertByteArrayToGuid(object value)
         {
+            if (value is OracleBinary oracleBinary)
+            {
+                try
+                {
+                    return new Guid(oracleBinary.Value);
+                }
+                catch (OracleNullValueException)
+                {
+                    return DBNull.Value;
+                }
+            }
             byte[] buffer = (byte[])value;
             if (buffer.Length == 0)
             {


### PR DESCRIPTION
in test `CommonFixture.GuidIsPassedAsPrameterAndReturnedAsOutput()` of Data.BVT project, `OracleDatabase.ConvertByteArrayToGuid()` tries to cast an `OracleBinary` to `byte[]`. The cast fails with the error:

>System.InvalidCastException: Unable to cast object of type 'Oracle.ManagedDataAccess.Types.OracleBinary' to type 'System.Byte[]'.

This PR uses `.Value` instead of trying to cast to `byte[]`.

this fixes issue #23 .