### PR TITLE
Fix connection strings to LocalDB

### DIFF
--- a/source/.runsettings
+++ b/source/.runsettings
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- x86 or x64 -->
+    <!-- This is required because the Oracle client library is x64 -->
+    <TargetPlatform>x64</TargetPlatform>
+  </RunConfiguration>
+</RunSettings>

--- a/source/Tests/Data.Tests/GenericDatabaseFixture.cs
+++ b/source/Tests/Data.Tests/GenericDatabaseFixture.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Practices.EnterpriseLibrary.Data.Tests
                 new DatabaseProviderFactory(new SystemConfigurationSource(false)).Create("OdbcDatabase");
 
             Assert.IsNotNull(database);
-            Assert.AreEqual(database.GetType(), typeof(GenericDatabase));
-            Assert.AreEqual(database.DbProviderFactory.GetType(), typeof(OdbcFactory));
-            Assert.AreEqual(connectionString, database.ConnectionStringWithoutCredentials);
+            Assert.AreEqual(typeof(GenericDatabase), database.GetType());
+            Assert.AreEqual(typeof(OdbcFactory), database.DbProviderFactory.GetType());
+            Assert.AreEqual(database.ConnectionStringWithoutCredentials, connectionString);
         }
 
         [TestMethod]

--- a/source/Tests/Data.Tests/GenericDatabaseFixture.cs
+++ b/source/Tests/Data.Tests/GenericDatabaseFixture.cs
@@ -6,6 +6,8 @@ using System.Data;
 using System.Data.Common;
 using System.Data.Odbc;
 using System.Data.SqlClient;
+using System.IO;
+using System.Reflection;
 using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -37,8 +39,8 @@ namespace Microsoft.Practices.EnterpriseLibrary.Data.Tests
         [TestMethod]
         public void CanDoExecuteDataReaderForGenericDatabaseBug1836()
         {
-            Database db = new GenericDatabase(@"Driver={Microsoft Access Driver (*.mdb)};Dbq=northwind.mdb;Uid=sa;Pwd=sa;", OdbcFactory.Instance);
-
+            Database db = new GenericDatabase($@"Driver={{Microsoft Access Driver (*.mdb, *.accdb)}};Dbq={Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}\Northwind.mdb;Uid=sa;Pwd=sa;", OdbcFactory.Instance);
+            
             using (DbConnection connection = db.CreateConnection())
             {
                 connection.Open();

--- a/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
+++ b/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
@@ -34,7 +34,7 @@
     <add
 				name="Service_Dflt"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;Integrated Security=true" />
+				connectionString="server=(localdb)\v11.0;database=Northwind;Integrated Security=true" />
     <add
 				name="OracleTest"
 				providerName="Oracle.ManagedDataAccess.Client"

--- a/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
+++ b/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
@@ -27,7 +27,7 @@
   </system.data>
 
   <appSettings>
-    <add key="SqlServerDatabaseInstance" value="(local)" />
+    <add key="SqlServerDatabaseInstance" value="(localdb)\v11.0" />
   </appSettings>
 
   <connectionStrings>

--- a/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
+++ b/source/Tests/Data.Tests/Microsoft.Practices.EnterpriseLibrary.Data.Tests.dll.config
@@ -54,15 +54,15 @@
     <add
 				name="NewDatabase"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;Integrated Security=true"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;Integrated Security=true"/>
     <add
 				name="DbWithSqlServerAuthn"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;uid=sa;pwd=mypassword"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;uid=sa;pwd=mypassword"/>
     <add
 				name="NorthwindPersistFalse"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;uid=entlib;pwd=hdf7&amp;834k(*KA;Persist Security Info=false"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;uid=entlib;pwd=hdf7&amp;834k(*KA;Persist Security Info=false"/>
     <add
 				name="no provider"
 				connectionString="server=(local);database=Northwind;Integrated Security=true" />

--- a/source/Tests/Data.Tests/testhost.dll.config
+++ b/source/Tests/Data.Tests/testhost.dll.config
@@ -7,14 +7,14 @@
   </configSections>
 
   <appSettings>
-    <add key="SqlServerDatabaseInstance" value="(local)" />
+    <add key="SqlServerDatabaseInstance" value="(localdb)\v11.0" />
   </appSettings>
 
   <connectionStrings>
     <add
 				name="Service_Dflt"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;Integrated Security=true" />
+				connectionString="server=(localdb)\v11.0;database=Northwind;Integrated Security=true" />
     <add
 				name="OracleTest"
 				providerName="Oracle.ManagedDataAccess.Client"
@@ -34,15 +34,15 @@
     <add
 				name="NewDatabase"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;Integrated Security=true"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;Integrated Security=true"/>
     <add
 				name="DbWithSqlServerAuthn"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;uid=sa;pwd=mypassword"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;uid=sa;pwd=mypassword"/>
     <add
 				name="NorthwindPersistFalse"
 				providerName="System.Data.SqlClient"
-				connectionString="server=(local);database=Northwind;uid=entlib;pwd=hdf7&amp;834k(*KA;Persist Security Info=false"/>
+				connectionString="server=(localdb)\v11.0;database=Northwind;uid=entlib;pwd=hdf7&amp;834k(*KA;Persist Security Info=false"/>
     <add
 				name="no provider"
 				connectionString="server=(local);database=Northwind;Integrated Security=true" />


### PR DESCRIPTION
In the future, we may want to update this to SQL Express 2016+ LocalDB instance name.
added a .runsettings file, to force test to run in 64 bit, to match the ODBC driver bitness.