### PR TITLE
Fix #32

### DIFF
--- a/source/Src/Data/Configuration/DatabaseSyntheticConfigSettings.cs
+++ b/source/Src/Data/Configuration/DatabaseSyntheticConfigSettings.cs
@@ -158,7 +158,10 @@ namespace Microsoft.Practices.EnterpriseLibrary.Data.Configuration
         private static bool IsValidProviderName(string providerName)
         {
 #if NETCOREAPP3_0
-            DbProviderFactories.RegisterFactory(providerName, typeof(System.Data.SqlClient.SqlClientFactory));
+            if (!String.IsNullOrEmpty(providerName))
+            {
+                DbProviderFactories.RegisterFactory(providerName, typeof(SqlClientFactory));
+            }
 #endif
             return DbProviderFactories.GetFactoryClasses().Rows.Find(providerName) != null;
         }

--- a/source/Src/Data/Configuration/DatabaseSyntheticConfigSettings.cs
+++ b/source/Src/Data/Configuration/DatabaseSyntheticConfigSettings.cs
@@ -157,12 +157,6 @@ namespace Microsoft.Practices.EnterpriseLibrary.Data.Configuration
 
         private static bool IsValidProviderName(string providerName)
         {
-#if NETCOREAPP3_0
-            if (!String.IsNullOrEmpty(providerName))
-            {
-                DbProviderFactories.RegisterFactory(providerName, typeof(SqlClientFactory));
-            }
-#endif
             return DbProviderFactories.GetFactoryClasses().Rows.Find(providerName) != null;
         }
 


### PR DESCRIPTION
This essentially fixes #32 . I didn't realize a validation method will alter the object it is validating, to map any tested provider name to `SqlClientFactory`, which is why any bogus provider name returned an `SqlDatabase`.
https://github.com/EnterpriseLibrary/data-access-application-block/blob/5dd739905814ed41123c9885bd14963bd675a970/source/Src/Data/Configuration/DatabaseSyntheticConfigSettings.cs#L161

As of now, all tests pass, except one reported as #31 